### PR TITLE
Fix migration table name

### DIFF
--- a/database/migrations/3_add_unsuppressed_at_to_mail_events.php.stub
+++ b/database/migrations/3_add_unsuppressed_at_to_mail_events.php.stub
@@ -11,13 +11,13 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('mail_events', function (Blueprint $table): void {
+        Schema::table(config('mails.database.tables.events', 'mail_events'), function (Blueprint $table): void {
             $table->timestamp('unsuppressed_at')
                 ->nullable()
                 ->after('occurred_at');
         });
 
-        Schema::table('mails', function (Blueprint $table): void {
+        Schema::table(config('mails.database.tables.mails', 'mails'), function (Blueprint $table): void {
             $table->string('mailer')
                 ->after('uuid');
 


### PR DESCRIPTION
Hi there and thanks for all the work on this package! I think you forgot to consider differently configured table names in the latest migration. Thanks a lot!