### PR TITLE
Better Unknown event type exception with event name 

### DIFF
--- a/src/Drivers/MailDriver.php
+++ b/src/Drivers/MailDriver.php
@@ -5,6 +5,7 @@ namespace Vormkracht10\Mails\Drivers;
 use Exception;
 use Illuminate\Support\Str;
 use Vormkracht10\Mails\Models\Mail;
+use Vormkracht10\Mails\Exceptions\UnknownEventTypeException;
 
 abstract class MailDriver
 {
@@ -56,7 +57,7 @@ abstract class MailDriver
             }
         }
 
-        throw new Exception('Unknown event type');
+        throw new UnknownEventTypeException('Unknown event type ' .  data_get($payload, 'RecordType', ''));
     }
 
     public function logMailEvent($payload): void

--- a/src/Exceptions/UnknownEventTypeException.php
+++ b/src/Exceptions/UnknownEventTypeException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Vormkracht10\Mails\Exceptions;
+
+use Exception;
+
+class UnknownEventTypeException extends Exception {}


### PR DESCRIPTION
This PR adds better exceptions for unknown events. 

The best solution is to fix this issue https://github.com/vormkracht10/laravel-mails/issues/46. But changes in this PR can be useful in the future to know which type of events the package can not handle. 