### PR TITLE
Add longText migration

### DIFF
--- a/database/migrations/5_change_link_to_long_text.php.stub
+++ b/database/migrations/5_change_link_to_long_text.php.stub
@@ -9,7 +9,7 @@ return new class extends Migration
     public function up()
     {
         Schema::table(config('mails.database.tables.events', 'mail_events'), function (Blueprint $table) {
-            $table->longText('link')->change();
+            $table->longText('link')->nullable()->change();
         });
         
     }
@@ -17,7 +17,7 @@ return new class extends Migration
     public function down()
     {
         Schema::table(config('mails.database.tables.events', 'mail_events'), function (Blueprint $table) {
-            $table->string('link')->change();
+            $table->string('link')->nullable()->change();
         });
     }
 };


### PR DESCRIPTION
This pull request introduces a database migration to modify the `link` column in the `mail_events` table. The change updates the column type from `string` to `longText` to accommodate longer URLs or text.

Database migration changes:

* [`database/migrations/5_change_link_to_long_text.php.stub`](diffhunk://#diff-1047b33e254eaa6838ca93ff22555100516030f80f82b48e3abf0e9f7e322944R1-R25): Added a migration to change the `link` column in the `mail_events` table from `string` to `longText` in the `up` method, with a corresponding reversal in the `down` method.