### PR TITLE
Restore removed code, add mail_class support, and fix tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ testbench.yaml
 vendor
 node_modules
 .DS_Store
+.claude/worktrees/

--- a/src/Actions/AttachUuid.php
+++ b/src/Actions/AttachUuid.php
@@ -15,13 +15,13 @@ class AttachUuid
     {
         $provider = $this->getProvider($messageSending);
 
-        if (! $this->shouldTrackMails($provider)) {
-            return $messageSending;
-        }
-
         $uuid = Str::uuid()->toString();
 
         $messageSending->message->getHeaders()->addTextHeader(config('mails.headers.uuid'), $uuid);
+
+        if (! $this->shouldTrackMails($provider)) {
+            return $messageSending;
+        }
 
         return MailProvider::with($provider)->attachUuidToMail($messageSending, $uuid);
     }

--- a/src/Actions/LogMail.php
+++ b/src/Actions/LogMail.php
@@ -98,7 +98,7 @@ class LogMail
     {
         return [
             'uuid' => $this->getCustomUuid($event),
-            // 'mail_class' => $this->getMailClassHeaderValue($event),
+            'mail_class' => $event->data['__laravel_mailable'] ?? $event->data['__laravel_notification'] ?? null,
             'sent_at' => $event instanceof MessageSent ? now() : null,
             'mailer' => $event->data['mailer'],
             'stream_id' => $this->getStreamId($event),

--- a/src/Drivers/ResendDriver.php
+++ b/src/Drivers/ResendDriver.php
@@ -4,25 +4,133 @@ namespace Backstage\Mails\Laravel\Drivers;
 
 use Backstage\Mails\Laravel\Contracts\MailDriverContract;
 use Backstage\Mails\Laravel\Enums\EventType;
+use Backstage\Mails\Laravel\Enums\Provider;
 use Illuminate\Http\Client\Response;
 use Illuminate\Mail\Events\MessageSending;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\URL;
 
 class ResendDriver extends MailDriver implements MailDriverContract
 {
     public function registerWebhooks($components): void
     {
-        $components->warn("Resend doesn't allow registering webhooks via the API. ");
-        $components->info('Please register your webhooks manually in the Resend dashboard.');
+        $trackingConfig = (array) config('mails.logging.tracking');
+
+        $apiKey = (string) config('services.resend.key');
+        $webhookUrl = URL::signedRoute('mails.webhook', ['provider' => Provider::RESEND]);
+
+        $events = [];
+
+        if ((bool) $trackingConfig['deliveries']) {
+            $events[] = 'email.sent';
+            $events[] = 'email.delivered';
+        }
+
+        if ((bool) $trackingConfig['opens']) {
+            $events[] = 'email.opened';
+        }
+
+        if ((bool) $trackingConfig['clicks']) {
+            $events[] = 'email.clicked';
+        }
+
+        if ((bool) $trackingConfig['bounces']) {
+            $events[] = 'email.bounced';
+            $events[] = 'email.delivery_delayed';
+        }
+
+        if ((bool) $trackingConfig['complaints']) {
+            $events[] = 'email.complained';
+        }
+
+        $existingWebhooks = Http::withToken($apiKey)
+            ->get('https://api.resend.com/webhooks');
+
+        $existing = collect($existingWebhooks->json('data') ?? [])
+            ->firstWhere('endpoint', $webhookUrl);
+
+        if ($existing) {
+            $components->info('Resend webhook already exists for this endpoint.');
+            $components->info('Webhook ID: '.$existing['id']);
+
+            return;
+        }
+
+        $response = Http::withToken($apiKey)
+            ->post('https://api.resend.com/webhooks', [
+                'endpoint' => $webhookUrl,
+                'events' => $events,
+            ]);
+
+        if ($response->successful()) {
+            $signingSecret = $response->json('signing_secret');
+
+            $components->info('Created Resend webhook successfully.');
+            $components->warn('Save this signing secret to your config as services.resend.webhook_signing_secret:');
+            $components->info($signingSecret);
+        } else {
+            $components->error('Failed to create Resend webhook.');
+            $components->error($response->json('message') ?? $response->body());
+        }
     }
 
     public function verifyWebhookSignature(array $payload): bool
     {
-        return true;
+        if (app()->runningUnitTests()) {
+            return true;
+        }
+
+        $secret = (string) config('services.resend.webhook_signing_secret');
+
+        if (empty($secret)) {
+            return true;
+        }
+
+        $request = request();
+
+        $svixId = $request->header('svix-id');
+        $svixTimestamp = $request->header('svix-timestamp');
+        $svixSignature = $request->header('svix-signature');
+
+        if (empty($svixId) || empty($svixTimestamp) || empty($svixSignature)) {
+            return false;
+        }
+
+        // Verify timestamp is within tolerance (5 minutes)
+        $tolerance = 5 * 60;
+        if (abs(time() - (int) $svixTimestamp) > $tolerance) {
+            return false;
+        }
+
+        // Strip the whsec_ prefix and base64 decode the secret
+        $secretBytes = base64_decode(str_replace('whsec_', '', $secret));
+
+        // Construct the signed content: msg_id.timestamp.body
+        $body = (string) $request->getContent();
+        $signedContent = "{$svixId}.{$svixTimestamp}.{$body}";
+
+        // Compute expected signature using HMAC-SHA256
+        $expectedSignature = base64_encode(hash_hmac('sha256', $signedContent, $secretBytes, true));
+
+        // The svix-signature header may contain multiple signatures separated by spaces
+        $signatures = explode(' ', $svixSignature);
+
+        foreach ($signatures as $signature) {
+            // Strip version prefix (v1,)
+            $parts = explode(',', $signature, 2);
+            $signatureValue = $parts[1] ?? $parts[0];
+
+            if (hash_equals($expectedSignature, $signatureValue)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function getUuidFromPayload(array $payload): ?string
     {
-        return collect($payload['data']['headers'])
+        return collect($payload['data']['headers'] ?? [])
             ->where('name', config('mails.headers.uuid'))
             ->first()['value'] ?? null;
     }
@@ -51,6 +159,7 @@ class ResendDriver extends MailDriver implements MailDriverContract
             'ip_address' => 'data.click.ipAddress',
             'link' => 'data.click.link',
             'user_agent' => 'data.click.userAgent',
+            'tag' => 'data.tags',
         ];
     }
 

--- a/src/Models/Mail.php
+++ b/src/Models/Mail.php
@@ -198,6 +198,16 @@ class Mail extends Model
         return $builder->whereNull('sent_at');
     }
 
+    public function scopeForUuid(Builder $builder, string $uuid): Builder
+    {
+        return $builder->where('uuid', $uuid);
+    }
+
+    public function scopeForMailClass(Builder $builder, string $mailClass): Builder
+    {
+        return $builder->where('mail_class', $mailClass);
+    }
+
     protected function status(): Attribute
     {
         return Attribute::make(get: function () {

--- a/tests/Fixtures/TestMailable.php
+++ b/tests/Fixtures/TestMailable.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Backstage\Mails\Laravel\Tests\Fixtures;
+
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+
+class TestMailable extends Mailable
+{
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            from: 'from@example.com',
+            subject: 'Test Mailable',
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            htmlString: '<p>Test HTML content</p>',
+        );
+    }
+}

--- a/tests/MailClassTest.php
+++ b/tests/MailClassTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use Backstage\Mails\Laravel\Models\Mail as MailModel;
+use Backstage\Mails\Laravel\Tests\Fixtures\TestMailable;
+use Illuminate\Mail\Message;
+use Illuminate\Support\Facades\Mail;
+
+it('stores mail_class as FQCN when sending a Mailable class', function (): void {
+    Mail::to('recipient@example.com')->send(new TestMailable);
+
+    $mail = MailModel::latest()->first();
+
+    expect($mail)->not->toBeNull();
+    expect($mail->mail_class)->toBe(TestMailable::class);
+});
+
+it('stores mail_class as null when sending with a closure', function (): void {
+    Mail::send([], [], function (Message $message): void {
+        $message->to('recipient@example.com')
+            ->from('from@example.com')
+            ->subject('Closure Mail')
+            ->html('<p>HTML</p>');
+    });
+
+    $mail = MailModel::latest()->first();
+
+    expect($mail)->not->toBeNull();
+    expect($mail->mail_class)->toBeNull();
+});
+
+it('can query mails by mail_class using forMailClass scope', function (): void {
+    Mail::to('recipient@example.com')->send(new TestMailable);
+
+    Mail::send([], [], function (Message $message): void {
+        $message->to('other@example.com')
+            ->from('from@example.com')
+            ->subject('Closure Mail')
+            ->html('<p>HTML</p>');
+    });
+
+    expect(MailModel::count())->toBe(2);
+    expect(MailModel::forMailClass(TestMailable::class)->count())->toBe(1);
+    expect(MailModel::forMailClass(TestMailable::class)->first()->subject)->toBe('Test Mailable');
+});

--- a/tests/MailgunTest.php
+++ b/tests/MailgunTest.php
@@ -41,6 +41,7 @@ it('can receive incoming delivery webhook from mailgun', function (): void {
                 'transport' => 'smtp',
             ],
             'user-variables' => [
+                config('mails.headers.uuid') => $mail?->uuid,
                 'url' => [
                     'link' => 'https://example.com',
                     'title' => 'Omnivery',
@@ -152,6 +153,9 @@ it('can receive incoming hard bounce webhook from mailgun', function (): void {
         'event-data' => [
             'event' => 'failed',
             'severity' => 'permanent',
+            'user-variables' => [
+                config('mails.headers.uuid') => $mail?->uuid,
+            ],
             'envelope' => [
                 'sender' => 'bounce-d9bee8ac-b0e7-11ec-8086-57d93b186f66@notify.omnivery.com',
                 'sending-ip' => '185.136.201.130',
@@ -211,6 +215,9 @@ it('can receive incoming soft bounce webhook from mailgun', function (): void {
         'event-data' => [
             'event' => 'failed',
             'severity' => 'temporary',
+            'user-variables' => [
+                config('mails.headers.uuid') => $mail?->uuid,
+            ],
             'envelope' => [
                 'sender' => 'bounce-d9bee8ac-b0e7-11ec-8086-57d93b186f66@notify.omnivery.com',
                 'sending-ip' => '185.136.201.130',
@@ -332,6 +339,9 @@ it('can receive incoming open webhook from mailgun', function (): void {
         'event-data' => [
             'recipient-domain' => 'omnivery.com',
             'timestamp' => 1649408305,
+            'user-variables' => [
+                config('mails.headers.uuid') => $mail?->uuid,
+            ],
             'envelope' => [
                 'targets' => 'test@omnivery.com',
             ],

--- a/tests/ResendTest.php
+++ b/tests/ResendTest.php
@@ -1,12 +1,17 @@
 <?php
 
+use Backstage\Mails\Laravel\Drivers\ResendDriver;
 use Backstage\Mails\Laravel\Enums\EventType;
 use Backstage\Mails\Laravel\Enums\Provider;
 use Backstage\Mails\Laravel\Models\Mail as MailModel;
 use Backstage\Mails\Laravel\Models\MailEvent;
+use Illuminate\Console\View\Components\Factory;
+use Illuminate\Http\Request;
 use Illuminate\Mail\Message;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\URL;
+use Symfony\Component\Console\Output\BufferedOutput;
 
 use function Pest\Laravel\assertDatabaseHas;
 use function Pest\Laravel\post;
@@ -46,6 +51,40 @@ it('can receive incoming delivery webhook from resend', function (): void {
 
     assertDatabaseHas((new MailEvent)->getTable(), [
         'type' => EventType::DELIVERED->value,
+    ]);
+});
+
+it('can receive incoming sent webhook from resend', function (): void {
+    Mail::send([], [], function (Message $message): void {
+        $message->to('hey@danielhe4rt.dev')
+            ->from('local@computer.nl')
+            ->subject('Test')
+            ->text('Text')
+            ->html('<p>HTML</p>');
+    });
+
+    $mail = MailModel::latest()->first();
+
+    post(URL::signedRoute('mails.webhook', ['provider' => Provider::RESEND]), [
+        'created_at' => '2023-05-19T22:09:32Z',
+        'data' => [
+            'created_at' => '2025-01-09 14:17:29.059104+00',
+            'email_id' => 'dummy-id',
+            'headers' => [
+                [
+                    'name' => config('mails.headers.uuid'),
+                    'value' => $mail->uuid,
+                ],
+            ],
+            'from' => 'local@computer.nl',
+            'subject' => 'Test',
+            'to' => ['hey@danielhe4rt.dev'],
+        ],
+        'type' => 'email.sent',
+    ])->assertAccepted();
+
+    assertDatabaseHas((new MailEvent)->getTable(), [
+        'type' => EventType::ACCEPTED->value,
     ]);
 });
 
@@ -244,4 +283,169 @@ it('can receive incoming click webhook from resend', function (): void {
         'type' => EventType::CLICKED->value,
         'link' => 'https://resend.com',
     ]);
+});
+
+it('can register webhooks via resend api', function (): void {
+    config()->set('services.resend.key', 're_test_123');
+
+    Http::fake([
+        'api.resend.com/webhooks' => Http::sequence()
+            ->push(['object' => 'list', 'data' => []])
+            ->push([
+                'object' => 'webhook',
+                'id' => 'wh_test_123',
+                'signing_secret' => 'whsec_test_signing_secret',
+            ]),
+    ]);
+
+    $driver = new ResendDriver;
+
+    $output = new BufferedOutput;
+    $factory = new Factory($output);
+
+    $driver->registerWebhooks($factory);
+
+    Http::assertSentCount(2);
+    Http::assertSent(fn ($request) => $request->method() === 'GET' && $request->url() === 'https://api.resend.com/webhooks');
+    Http::assertSent(fn ($request) => $request->method() === 'POST'
+        && $request->url() === 'https://api.resend.com/webhooks'
+        && ! empty($request['endpoint'])
+        && ! empty($request['events'])
+    );
+});
+
+it('skips webhook registration when resend webhook already exists', function (): void {
+    config()->set('services.resend.key', 're_test_123');
+
+    $webhookUrl = URL::signedRoute('mails.webhook', ['provider' => Provider::RESEND]);
+
+    Http::fake([
+        'api.resend.com/webhooks' => Http::response([
+            'object' => 'list',
+            'data' => [
+                [
+                    'id' => 'wh_existing_123',
+                    'endpoint' => $webhookUrl,
+                    'events' => ['email.delivered'],
+                    'status' => 'enabled',
+                ],
+            ],
+        ]),
+    ]);
+
+    $driver = new ResendDriver;
+
+    $output = new BufferedOutput;
+    $factory = new Factory($output);
+
+    $driver->registerWebhooks($factory);
+
+    Http::assertSentCount(1);
+});
+
+it('verifies svix webhook signature correctly', function (): void {
+    $secret = 'whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw';
+    $secretBytes = base64_decode(str_replace('whsec_', '', $secret));
+
+    $body = json_encode(['type' => 'email.delivered', 'data' => ['email_id' => 'test']]);
+    $msgId = 'msg_test_123';
+    $timestamp = (string) time();
+    $signedContent = "{$msgId}.{$timestamp}.{$body}";
+    $signature = base64_encode(hash_hmac('sha256', $signedContent, $secretBytes, true));
+
+    config()->set('services.resend.webhook_signing_secret', $secret);
+
+    $driver = new ResendDriver;
+
+    // Simulate a request with Svix headers
+    $request = Request::create(
+        '/webhooks/mails/resend',
+        'POST',
+        [],
+        [],
+        [],
+        [
+            'HTTP_SVIX_ID' => $msgId,
+            'HTTP_SVIX_TIMESTAMP' => $timestamp,
+            'HTTP_SVIX_SIGNATURE' => "v1,{$signature}",
+            'CONTENT_TYPE' => 'application/json',
+        ],
+        $body,
+    );
+
+    app()->instance('request', $request);
+
+    // Override runningUnitTests to actually test verification
+    $this->app->detectEnvironment(fn () => 'production');
+
+    expect($driver->verifyWebhookSignature(json_decode($body, true)))->toBeTrue();
+});
+
+it('rejects invalid svix webhook signature', function (): void {
+    $secret = 'whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw';
+
+    $body = json_encode(['type' => 'email.delivered', 'data' => ['email_id' => 'test']]);
+    $msgId = 'msg_test_123';
+    $timestamp = (string) time();
+
+    config()->set('services.resend.webhook_signing_secret', $secret);
+
+    $driver = new ResendDriver;
+
+    $request = Request::create(
+        '/webhooks/mails/resend',
+        'POST',
+        [],
+        [],
+        [],
+        [
+            'HTTP_SVIX_ID' => $msgId,
+            'HTTP_SVIX_TIMESTAMP' => $timestamp,
+            'HTTP_SVIX_SIGNATURE' => 'v1,invalidsignature',
+            'CONTENT_TYPE' => 'application/json',
+        ],
+        $body,
+    );
+
+    app()->instance('request', $request);
+
+    $this->app->detectEnvironment(fn () => 'production');
+
+    expect($driver->verifyWebhookSignature(json_decode($body, true)))->toBeFalse();
+});
+
+it('rejects svix webhook with expired timestamp', function (): void {
+    $secret = 'whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw';
+    $secretBytes = base64_decode(str_replace('whsec_', '', $secret));
+
+    $body = json_encode(['type' => 'email.delivered', 'data' => ['email_id' => 'test']]);
+    $msgId = 'msg_test_123';
+    $timestamp = (string) (time() - 600); // 10 minutes ago
+    $signedContent = "{$msgId}.{$timestamp}.{$body}";
+    $signature = base64_encode(hash_hmac('sha256', $signedContent, $secretBytes, true));
+
+    config()->set('services.resend.webhook_signing_secret', $secret);
+
+    $driver = new ResendDriver;
+
+    $request = Request::create(
+        '/webhooks/mails/resend',
+        'POST',
+        [],
+        [],
+        [],
+        [
+            'HTTP_SVIX_ID' => $msgId,
+            'HTTP_SVIX_TIMESTAMP' => $timestamp,
+            'HTTP_SVIX_SIGNATURE' => "v1,{$signature}",
+            'CONTENT_TYPE' => 'application/json',
+        ],
+        $body,
+    );
+
+    app()->instance('request', $request);
+
+    $this->app->detectEnvironment(fn () => 'production');
+
+    expect($driver->verifyWebhookSignature(json_decode($body, true)))->toBeFalse();
 });

--- a/tests/SmtpTest.php
+++ b/tests/SmtpTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use Backstage\Mails\Laravel\Models\Mail as MailModel;
+use Illuminate\Mail\Message;
+use Illuminate\Support\Facades\Mail;
+
+beforeEach(function (): void {
+    config()->set('mail.mailers.smtp', [
+        'transport' => 'smtp',
+    ]);
+});
+
+it('attaches uuid to smtp mails when logging is enabled', function (): void {
+    Mail::send([], [], function (Message $message): void {
+        $message->to('mark@vormkracht10.nl')
+            ->from('local@computer.nl')
+            ->subject('Test')
+            ->text('Text');
+    });
+
+    $mail = MailModel::latest()->first();
+
+    expect($mail)->not->toBeNull();
+    expect($mail->uuid)->not->toBeNull();
+});
+
+it('sets sent_at for smtp mails', function (): void {
+    Mail::send([], [], function (Message $message): void {
+        $message->to('mark@vormkracht10.nl')
+            ->from('local@computer.nl')
+            ->subject('Test')
+            ->text('Text');
+    });
+
+    $mail = MailModel::latest()->first();
+
+    expect($mail)->not->toBeNull();
+    expect($mail->sent_at)->not->toBeNull();
+});
+
+it('logs smtp mail with correct attributes', function (): void {
+    Mail::send([], [], function (Message $message): void {
+        $message->to('mark@vormkracht10.nl')
+            ->from('local@computer.nl')
+            ->cc('cc@vk10.nl')
+            ->bcc('bcc@vk10.nl')
+            ->subject('Test')
+            ->text('Text')
+            ->html('<p>HTML</p>');
+    });
+
+    $mail = MailModel::latest()->first();
+
+    expect($mail)->not->toBeNull();
+    expect($mail->uuid)->not->toBeNull();
+    expect($mail->sent_at)->not->toBeNull();
+    expect($mail->from)->toEqual(['local@computer.nl' => null]);
+    expect($mail->to)->toEqual(['mark@vormkracht10.nl' => null]);
+    expect($mail->cc)->toEqual(['cc@vk10.nl' => null]);
+    expect($mail->bcc)->toEqual(['bcc@vk10.nl' => null]);
+    expect($mail->subject)->toBe('Test');
+    expect($mail->html)->toBe('<p>HTML</p>');
+    expect($mail->text)->toBe('Text');
+});
+
+it('does not attach uuid to smtp mails when logging is disabled', function (): void {
+    config()->set('mails.logging.enabled', false);
+
+    Mail::send([], [], function (Message $message): void {
+        $message->to('mark@vormkracht10.nl')
+            ->from('local@computer.nl')
+            ->subject('Test')
+            ->text('Text');
+    });
+
+    expect(MailModel::count())->toBe(0);
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -18,7 +18,7 @@ class TestCase extends Orchestra
         parent::setUp();
 
         Factory::guessFactoryNamesUsing(
-            fn (string $modelName): string => 'Backstage\\Mails\\Database\\Factories\\'.class_basename($modelName).'Factory'
+            fn (string $modelName): string => 'Backstage\\Mails\\Laravel\\Database\\Factories\\'.class_basename($modelName).'Factory'
         );
 
         $this->loadMigrations();


### PR DESCRIPTION
## Summary
- Restore Resend webhook registration via API and Svix signature verification that were removed during the namespace rename
- Add `mail_class` logging from Laravel's `__laravel_mailable` event data
- Add `forUuid` and `forMailClass` query scopes to Mail model
- Always attach UUID to mails regardless of provider driver (AttachUuid)
- Fix mailgun test payloads to include `user-variables` with UUID
- Add SMTP, MailClass, and Resend webhook/signature tests
- Fix TestCase factory namespace

## Test plan
- [x] All 38 tests pass (`vendor/bin/pest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)