### PR TITLE
Remove spatie/laravel-ray conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,9 +68,6 @@
             "php-http/discovery": true
         }
     },
-    "conflict": {
-        "spatie/laravel-ray": "*"
-    },
     "extra": {
         "laravel": {
             "providers": [


### PR DESCRIPTION
The blanket `"conflict": { "spatie/laravel-ray": "*" }` prevents consumers from using Ray for debugging in projects that depend on this package.

There is no technical incompatibility between laravel-mails and laravel-ray — this constraint unnecessarily forces users to choose between the two packages.

This PR simply removes the conflict entry so that both packages can coexist.