### PR TITLE
Add AssociatedMailMessage for notification model association

### DIFF
--- a/src/Messages/AssociatedMailMessage.php
+++ b/src/Messages/AssociatedMailMessage.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Backstage\Mails\Laravel\Messages;
+
+use Backstage\Mails\Laravel\Contracts\HasAssociatedMails;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Support\Collection;
+use Symfony\Component\Mime\Email;
+
+class AssociatedMailMessage extends MailMessage
+{
+    /**
+     * @param  Model|Collection|array<Model&HasAssociatedMails>  $models
+     */
+    public function associateModels(Model|Collection|array $models): static
+    {
+        if ($models instanceof Collection) {
+            $models = $models->all();
+        } elseif ($models instanceof Model) {
+            $models = [$models];
+        }
+
+        $identifiers = [];
+
+        foreach ($models as $model) {
+            $identifiers[] = [$model::class, $model->getKeyName(), $model->getKey()];
+        }
+
+        $this->withSymfonyMessage(function (Email $email) use ($identifiers) {
+            $header = config('mails.headers.associate', 'X-Mails-Associated-Models');
+
+            if ($email->getHeaders()->has($header)) {
+                return;
+            }
+
+            $email->getHeaders()->addTextHeader(
+                $header,
+                encrypt(json_encode($identifiers)),
+            );
+        });
+
+        return $this;
+    }
+}

--- a/tests/AssociatedMailMessageTest.php
+++ b/tests/AssociatedMailMessageTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use Backstage\Mails\Laravel\Models\Mail as MailModel;
+use Backstage\Mails\Laravel\Tests\Fixtures\TestModel;
+use Backstage\Mails\Laravel\Tests\Fixtures\TestNotification;
+use Illuminate\Support\Facades\Schema;
+
+use function Pest\Laravel\assertDatabaseHas;
+
+beforeEach(function () {
+    Schema::create('test_models', function ($table) {
+        $table->id();
+        $table->string('name')->nullable();
+        $table->string('email')->nullable();
+        $table->timestamps();
+    });
+});
+
+afterEach(function () {
+    Schema::dropIfExists('test_models');
+});
+
+it('sends a notification with associated models and creates mail and pivot records', function () {
+    $model = TestModel::create(['name' => 'Test', 'email' => 'test@example.com']);
+
+    $model->notify(new TestNotification([$model]));
+
+    $mail = MailModel::latest()->first();
+
+    expect($mail)->not->toBeNull();
+    expect($mail->subject)->toBe('Test Notification');
+
+    assertDatabaseHas('mailables', [
+        'mail_id' => $mail->id,
+        'mailable_type' => TestModel::class,
+        'mailable_id' => $model->id,
+    ]);
+});
+
+it('associates multiple models with a notification', function () {
+    $modelA = TestModel::create(['name' => 'Model A', 'email' => 'a@example.com']);
+    $modelB = TestModel::create(['name' => 'Model B', 'email' => 'b@example.com']);
+
+    $modelA->notify(new TestNotification([$modelA, $modelB]));
+
+    $mail = MailModel::latest()->first();
+
+    expect($mail)->not->toBeNull();
+
+    assertDatabaseHas('mailables', [
+        'mail_id' => $mail->id,
+        'mailable_type' => TestModel::class,
+        'mailable_id' => $modelA->id,
+    ]);
+
+    assertDatabaseHas('mailables', [
+        'mail_id' => $mail->id,
+        'mailable_type' => TestModel::class,
+        'mailable_id' => $modelB->id,
+    ]);
+});
+
+it('sends a notification without associated models', function () {
+    $model = TestModel::create(['name' => 'Test', 'email' => 'test@example.com']);
+
+    $model->notify(new TestNotification);
+
+    $mail = MailModel::latest()->first();
+
+    expect($mail)->not->toBeNull();
+    expect($mail->subject)->toBe('Test Notification');
+
+    expect(
+        \Illuminate\Support\Facades\DB::table('mailables')
+            ->where('mail_id', $mail->id)
+            ->exists()
+    )->toBeFalse();
+});

--- a/tests/Fixtures/TestModel.php
+++ b/tests/Fixtures/TestModel.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Backstage\Mails\Laravel\Tests\Fixtures;
+
+use Backstage\Mails\Laravel\Contracts\HasAssociatedMails;
+use Backstage\Mails\Laravel\Traits\HasMails;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Notifications\Notifiable;
+
+class TestModel extends Model implements HasAssociatedMails
+{
+    use HasMails, Notifiable;
+
+    protected $table = 'test_models';
+
+    protected $guarded = [];
+}

--- a/tests/Fixtures/TestNotification.php
+++ b/tests/Fixtures/TestNotification.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Backstage\Mails\Laravel\Tests\Fixtures;
+
+use Backstage\Mails\Laravel\Messages\AssociatedMailMessage;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Notifications\Notification;
+
+class TestNotification extends Notification
+{
+    /**
+     * @param  array<Model>  $models
+     */
+    public function __construct(
+        protected array $models = [],
+    ) {}
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): AssociatedMailMessage
+    {
+        $message = (new AssociatedMailMessage)
+            ->from('from@example.com')
+            ->subject('Test Notification')
+            ->line('This is a test notification.');
+
+        if (! empty($this->models)) {
+            $message->associateModels($this->models);
+        }
+
+        return $message;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `AssociatedMailMessage` class extending `MailMessage` with a fluent `associateModels()` method for linking Eloquent models to emails sent via notifications
- Reuses the existing `X-Mails-Associated-Models` header strategy so `StoreMailRelations` works unchanged — no changes to listeners, config, or migrations
- Includes integration tests covering single model, multiple models, and no-models scenarios

Closes #71

## Test plan
- [x] Send notification with `AssociatedMailMessage` + `associateModels()` → mail record + pivot records created
- [x] Multiple models associated correctly
- [x] Notification without associated models works without creating pivot records
- [x] Full test suite passes (41 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)